### PR TITLE
Add separate visitor implementation for PowerShell version 7

### DIFF
--- a/src/Classes/AstVisitor7.class.ps1
+++ b/src/Classes/AstVisitor7.class.ps1
@@ -527,5 +527,22 @@ class PSPVisitor : ICustomAstVisitor,ICustomAstVisitor2
         $newElements = $this.VisitElements($dynamicKeywordAst.CommandElements)
         return [DynamicKeywordStatementAst]::new($dynamicKeywordAst.Extent, $newElements)
     }
+
+    # V7 nodes
+    [object] VisitTernaryExpression([TernaryExpressionAst]$ternaryExpressionAst)
+    {
+        $newCondition = $this.VisitElement($ternaryExpressionAst.Condition)
+        $newIfTrue = $this.VisitElement($ternaryExpressionAst.IfTrue)
+        $newIfFalse = $this.VisitElement($ternaryExpressionAst.IfFalse)
+        return [TernaryExpressionAst]::new($ternaryExpressionAst.Extent, $newCondition, $newIfTrue, $newIfFalse)
+    }
+
+    [object] VisitPipelineChain([PipelineChainAst]$pipelineChainAst)
+    {
+        $newOperator = $this.VisitElement($pipelineChainAst.Operator)
+        $newLhsPipeline = $this.VisitElement($pipelineChainAst.LhsPipelineChain)
+        $newRhsPipeline = $this.VisitElement($pipelineChainAst.RhsPipeline)
+        return [PipelineChainAst]::new($pipelineChainAst.Extent, $newOperator, $newLhsPipeline, $newRhsPipeline)
+    }
 }
 #endregion

--- a/src/PSProfiler.psm1
+++ b/src/PSProfiler.psm1
@@ -1,7 +1,6 @@
 $ErrorActionPreference = "Stop"
 
 # Attempt to retrieve relevant script files
-$Classes = Get-ChildItem (Join-Path $PSScriptRoot Classes) -ErrorAction SilentlyContinue -Filter *.class.ps1
 $Public  = Get-ChildItem (Join-Path $PSScriptRoot Public)  -ErrorAction SilentlyContinue -Filter *.ps1
 $Private = Get-ChildItem (Join-Path $PSScriptRoot Private) -ErrorAction SilentlyContinue -Filter *.ps1
 
@@ -22,17 +21,17 @@ foreach($classDependee in $ClassDependees)
     }
 }
 
-# import any remaining class files
-foreach($class in $Classes|Where-Object {($_.Name -replace '\.class\.ps1') -notin $ClassDependees})
-{
-    try{
-        . $class.fullname
+$Visitor = switch($PSVersionTable['PSVersion'].Major){
+    {$_ -ge 7} {
+        "AstVisitor7.class.ps1"
     }
-    catch{
-        Write-Error -Message "Failed to import dependant class $($class.fullname): $_"
-    }    
+    default {
+        "AstVisitor.class.ps1"
+    }
 }
 
+Write-Verbose "Loading '$Visitor'"
+. (Join-Path (Join-Path $PSScriptRoot .\Classes) $Visitor)
 # dot source the functions
 foreach($import in @($Public;$Private))
 {

--- a/src/Public/Measure-Script.ps1
+++ b/src/Public/Measure-Script.ps1
@@ -100,7 +100,7 @@ Function Measure-Script {
     }
 
     $profiler = [Profiler]::new($Ast.Extent)
-    $visitor  = [AstVisitor]::new($profiler)
+    $visitor  = [PSPVisitor]::new($profiler)
     $newAst   = $Ast.Visit($visitor)
 
     $MeasureScriptblock = $newAst.GetScriptBlock()


### PR DESCRIPTION
PowerShell 7.0 introduces two new syntax types (pipeline chain operators and ternary expressions).
Unfortunately, these were introduced by modifying the existing AstVisitor interfaces, meaning a PS Class implementation of the pre-7 visitor interface never works in version 7, and vice versa.

To avoid maintaining two separate release channels, this commit introduces a separate visitor implementation in its own script file - allowing us to defer type definition until module load