### PR TITLE
add color for top 5 slowest times

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+publish/

--- a/build.ps1
+++ b/build.ps1
@@ -15,7 +15,7 @@ $ClassDependees = @(
     'Profiler'
 )
 
-$publishDir = mkdir (Join-Path $PSScriptRoot publish\PSProfiler) @PSBoundParameters
+$publishDir = New-Item -ItemType Directory -Path (Join-Path $PSScriptRoot publish\PSProfiler) @PSBoundParameters
 
 $moduleFile = New-Item -Path $publishDir.FullName -Name "PSProfiler.psm1" -ItemType File @PSBoundParameters
 

--- a/src/PSProfiler.format.ps1xml
+++ b/src/PSProfiler.format.ps1xml
@@ -75,7 +75,7 @@ FormatData for MeasureScript
                             <TableColumnItem>
                                 <ScriptBlock>
                                     if ($_.Top -and $PSStyle -ne $null) {
-                                        $PSStyle.Background.Red + ($_.ExecutionTime -f '{0:mm\:ss\.fffffff}') + $PSStyle.Reset
+                                        $PSStyle.Background.Red + ('{0:mm\:ss\.fffffff}' -f $_.ExecutionTime) + $PSStyle.Reset
                                     }
                                     else {
                                         $_.ExecutionTime -f '{0:mm\:ss\.fffffff}'

--- a/src/PSProfiler.format.ps1xml
+++ b/src/PSProfiler.format.ps1xml
@@ -73,8 +73,14 @@ FormatData for MeasureScript
                                 <PropertyName>LineNo</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
-                                <PropertyName>ExecutionTime</PropertyName>
-                                <FormatString>{0:mm\:ss\.fffffff}</FormatString>
+                                <ScriptBlock>
+                                    if ($_.Top -and $PSStyle -ne $null) {
+                                        $PSStyle.Background.Red + ($_.ExecutionTime -f '{0:mm\:ss\.fffffff}') + $PSStyle.Reset
+                                    }
+                                    else {
+                                        $_.ExecutionTime -f '{0:mm\:ss\.fffffff}'
+                                    }
+                                </ScriptBlock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>Line</PropertyName>

--- a/src/PSProfiler.format.ps1xml
+++ b/src/PSProfiler.format.ps1xml
@@ -78,7 +78,7 @@ FormatData for MeasureScript
                                         $PSStyle.Background.Red + ('{0:mm\:ss\.fffffff}' -f $_.ExecutionTime) + $PSStyle.Reset
                                     }
                                     else {
-                                        $_.ExecutionTime -f '{0:mm\:ss\.fffffff}'
+                                        '{0:mm\:ss\.fffffff}' -f $_.ExecutionTime
                                     }
                                 </ScriptBlock>
                             </TableColumnItem>

--- a/src/Public/Measure-Script.ps1
+++ b/src/Public/Measure-Script.ps1
@@ -117,13 +117,22 @@ Function Measure-Script {
     }
 
     [string[]]$lines = $Ast.Extent.ToString() -split '\r?\n' |ForEach-Object TrimEnd
+
+    $executionTimes = [System.Collections.Generic.List[TimeSpan]]::new()
+    for($i = 0; $i -lt $lines.Count;$i++){
+        $executionTimes.Add($profiler.TimeLines[$i].GetTotal())
+    }
+
+    $top5 = $executionTimes.Ticks | Sort-Object -Descending | Select-Object -First 5
+
     for($i = 0; $i -lt $lines.Count;$i++){
         [pscustomobject]@{
             LineNo        = $i + 1
-            ExecutionTime = $profiler.TimeLines[$i].GetTotal()
+            ExecutionTime = $executionTimes[$i]
             TimeLine      = $profiler.TimeLines[$i]
             Line          = $lines[$i]
             SourceScript  = $Source
+            Top           = ($top5 -contains $executionTimes[$i].Ticks)
             PSTypeName    = 'ScriptLineMeasurement'
         }
     }

--- a/src/Public/Measure-Script.ps1
+++ b/src/Public/Measure-Script.ps1
@@ -70,7 +70,9 @@ Function Measure-Script {
         [Parameter(Mandatory=$false,ParameterSetName="__AllParametersets")]
         [hashtable]$Arguments,
         [Parameter(Mandatory=$false,ParameterSetName="__AllParametersets")]
-        [string]$Name
+        [string]$Name,
+        [Parameter(Mandatory=$false,ParameterSetName="__AllParametersets")]
+        [int]$Top = 5
     )
 
     if($PSCmdlet.ParameterSetName -eq "Path") {
@@ -123,7 +125,10 @@ Function Measure-Script {
         $executionTimes.Add($profiler.TimeLines[$i].GetTotal())
     }
 
-    $top5 = $executionTimes.Ticks | Sort-Object -Descending | Select-Object -First 5
+    $topLimit = [long]::MaxValue
+    if($Top) {
+        $topLimit = $executionTimes.Ticks | Sort-Object -Descending | Select-Object -First 5 | Select-Object -Last 1
+    }
 
     for($i = 0; $i -lt $lines.Count;$i++){
         [pscustomobject]@{
@@ -132,7 +137,7 @@ Function Measure-Script {
             TimeLine      = $profiler.TimeLines[$i]
             Line          = $lines[$i]
             SourceScript  = $Source
-            Top           = ($top5 -contains $executionTimes[$i].Ticks)
+            Top           = $executionTimes[$i].Ticks -ge $topLimit
             PSTypeName    = 'ScriptLineMeasurement'
         }
     }
@@ -146,4 +151,3 @@ Function Measure-Script {
         }
     }
 }
-


### PR DESCRIPTION
Fix build.ps1 to work on macOS by using `new-item` instead of mkdir
Update `Measure-Script` to find top 5 slowest lines and mark them as `Top` using a new member
Update formatting where `Top` is `$true` and `$PSStyle` exists, then use a red background

This makes it easy to see which top 5 lines are slowest