### PR TITLE
Add `-HumanReadable` switch for ms duration formatting

### DIFF
--- a/Tests/AstVisitor.class.Tests.Ps1
+++ b/Tests/AstVisitor.class.Tests.Ps1
@@ -1,6 +1,6 @@
-﻿Import-Module "$PSScriptRoot\..\src\MeasureScript.psd1" -Force
+﻿Import-Module "$PSScriptRoot\..\src\PSProfiler.psd1" -Force
 
-InModuleScope -ModuleName MeasureScript -ScriptBlock {
+InModuleScope -ModuleName PSProfiler -ScriptBlock {
 
 Describe '[AstVisitor]-[Constructors]'{
 

--- a/Tests/Profiler.class.Tests.Ps1
+++ b/Tests/Profiler.class.Tests.Ps1
@@ -1,8 +1,8 @@
 ﻿
 
-Import-Module "$PSScriptRoot\..\src\MeasureScript.psd1" -Force
+Import-Module "$PSScriptRoot\..\src\PSProfiler.psd1" -Force
 
-InModuleScope  "MeasureScript"{
+InModuleScope  "PSProfiler"{
 
     Describe '[Profiler]-[Constructors]'{
 

--- a/Tests/TimeLine.class.Tests.Ps1
+++ b/Tests/TimeLine.class.Tests.Ps1
@@ -1,6 +1,6 @@
-﻿Import-Module "$PSScriptRoot\..\src\MeasureScript.psd1" -Force
+﻿Import-Module "$PSScriptRoot\..\src\PSProfiler.psd1" -Force
 
-InModuleScope -ModuleName MeasureScript -ScriptBlock {
+InModuleScope -ModuleName PSProfiler -ScriptBlock {
 
 
 Describe '[TimeLine]-[Constructors]'{
@@ -81,6 +81,23 @@ $Instance = [TimeLine]::New()
 ($Instance.GetTotal()).GetType().Name | should be TimeSpan
 
 } #End It Block
+
+It '[TimeLine] --> GetTotalFormatted() : [string] - should return type [string]' {    
+    $Instance = [TimeLine]::New()    
+    ($Instance.GetTotalFormatted($true)).GetType().Name | should be String
+}
+
+It '[TimeLine] --> GetTotalFormatted($true) : [string] - should return ms' {    
+    $Instance = [TimeLine]::New()    
+    $Instance.Add([TimeSpan]::FromMilliseconds(500))
+    $Instance.GetTotalFormatted($true) | should be "500ms"
+}
+
+It '[TimeLine] --> GetTotalFormatted($false) : [string] - should return timespan format' {    
+    $Instance = [TimeLine]::New()    
+    $Instance.Add([TimeSpan]::FromMilliseconds(500))
+    $Instance.GetTotalFormatted($false) | should be "00:00.5000000"
+}
 
 #Public Method
 It '[TimeLine] --> GetAverage() : [TimeSpan] - should Not Throw' {

--- a/src/Classes/TimeLine.class.ps1
+++ b/src/Classes/TimeLine.class.ps1
@@ -22,6 +22,14 @@ class TimeLine
         return $this.Total
     }
 
+    [String]GetTotalFormatted([boolean]$HumanReadable)
+    {
+        if ($HumanReadable) {
+            return '{0}ms' -f $([math]::Round($this.Total.TotalMilliseconds))
+        }
+        return '{0:mm\:ss\.fffffff}' -f $this.Total
+    }
+
     [TimeSpan]GetAverage()
     {
         if($count = $this.GetCount() -eq 0){

--- a/src/PSProfiler.format.ps1xml
+++ b/src/PSProfiler.format.ps1xml
@@ -75,10 +75,10 @@ FormatData for MeasureScript
                             <TableColumnItem>
                                 <ScriptBlock>
                                     if ($_.Top -and $PSStyle -ne $null) {
-                                        $PSStyle.Background.Red + ('{0:mm\:ss\.fffffff}' -f $_.ExecutionTime) + $PSStyle.Reset
+                                        $PSStyle.Background.Red + $_.Formatted + $PSStyle.Reset
                                     }
                                     else {
-                                        '{0:mm\:ss\.fffffff}' -f $_.ExecutionTime
+                                        return $_.Formatted
                                     }
                                 </ScriptBlock>
                             </TableColumnItem>

--- a/src/Public/Measure-Script.ps1
+++ b/src/Public/Measure-Script.ps1
@@ -54,7 +54,7 @@ Function Measure-Script {
           0     5    00:00.0000000
 
 .EXAMPLE
-    Measure-Scipt -Path c:\PS\GenerateUsername.ps1 -Arguments @{GivenName = "Joe";Surname = "Smith"}
+    Measure-Script -Path c:\PS\GenerateUsername.ps1 -Arguments @{GivenName = "Joe";Surname = "Smith"}
 
     This will execute and measure the c:\PS\GenerateUsername.ps1 script with the -GivenName and -Surname parameters.
 
@@ -72,7 +72,8 @@ Function Measure-Script {
         [Parameter(Mandatory=$false,ParameterSetName="__AllParametersets")]
         [string]$Name,
         [Parameter(Mandatory=$false,ParameterSetName="__AllParametersets")]
-        [int]$Top = 5
+        [int]$Top = 5,
+        [switch]$HumanReadable
     )
 
     if($PSCmdlet.ParameterSetName -eq "Path") {
@@ -135,6 +136,7 @@ Function Measure-Script {
             LineNo        = $i + 1
             ExecutionTime = $executionTimes[$i]
             TimeLine      = $profiler.TimeLines[$i]
+            Formatted     = $profiler.TimeLines[$i].GetTotalFormatted($HumanReadable)
             Line          = $lines[$i]
             SourceScript  = $Source
             Top           = $executionTimes[$i].Ticks -ge $topLimit


### PR DESCRIPTION
Salutations👋

I was using this script to speed up my pwsh startup time, and I found the duration formatting a bit hard to read

Is there any interest in a `-HumanReadable` flag or similar to format the durations?

```pwsh
~ ❯ pwsh -NoProfile {
    Import-Module ~\git\PSProfiler\src\PSProfiler.psd1
    Measure-Script -Path ~\git\posh-git\src\all.ps1
}

    ~\git\posh-git\src\all.ps1


      Count  Line       Time Taken Statement
      -----  ----       ---------- ---------
          0     1    00:00.0000000
          1     2    00:00.0412562 . $PSScriptRoot\ConsoleMode.ps1
          1     3    00:00.0323621 . $PSScriptRoot\Utils.ps1
          1     4    00:00.0093024 . $PSScriptRoot\AnsiUtils.ps1
          1     5    00:00.0035924 . $PSScriptRoot\WindowTitle.ps1
          1     6    00:00.0070591 . $PSScriptRoot\PoshGitTypes.ps1
          1     7    00:00.0085255 . $PSScriptRoot\GitUtils.ps1
          1     8    00:00.0501589 . $PSScriptRoot\GitPrompt.ps1
          1     9    00:00.0049326 . $PSScriptRoot\GitParamTabExpansion.ps1
          1    10    00:00.0839039 . $PSScriptRoot\GitTabExpansion.ps1
          1    11    00:00.0057058 . $PSScriptRoot\TortoiseGit.ps1

~ ❯ pwsh -NoProfile {
    Import-Module ~\git\PSProfiler\src\PSProfiler.psd1
    Measure-Script -HumanReadable -Path ~\git\posh-git\src\all.ps1
}

    ~\git\posh-git\src\all.ps1


      Count  Line       Time Taken Statement
      -----  ----       ---------- ---------
          0     1              0ms
          1     2             27ms . $PSScriptRoot\ConsoleMode.ps1
          1     3             31ms . $PSScriptRoot\Utils.ps1
          1     4              9ms . $PSScriptRoot\AnsiUtils.ps1
          1     5              4ms . $PSScriptRoot\WindowTitle.ps1
          1     6              7ms . $PSScriptRoot\PoshGitTypes.ps1
          1     7              8ms . $PSScriptRoot\GitUtils.ps1
          1     8             48ms . $PSScriptRoot\GitPrompt.ps1
          1     9              5ms . $PSScriptRoot\GitParamTabExpansion.ps1
          1    10             94ms . $PSScriptRoot\GitTabExpansion.ps1
          1    11              5ms . $PSScriptRoot\TortoiseGit.ps1

```