### PR TITLE
Fix #15 - chain operator bug

### DIFF
--- a/src/Classes/AstVisitor7.class.ps1
+++ b/src/Classes/AstVisitor7.class.ps1
@@ -539,10 +539,9 @@ class PSPVisitor : ICustomAstVisitor,ICustomAstVisitor2
 
     [object] VisitPipelineChain([PipelineChainAst]$pipelineChainAst)
     {
-        $newOperator = $this.VisitElement($pipelineChainAst.Operator)
         $newLhsPipeline = $this.VisitElement($pipelineChainAst.LhsPipelineChain)
         $newRhsPipeline = $this.VisitElement($pipelineChainAst.RhsPipeline)
-        return [PipelineChainAst]::new($pipelineChainAst.Extent, $newOperator, $newLhsPipeline, $newRhsPipeline)
+        return [PipelineChainAst]::new($pipelineChainAst.Extent, $newLhsPipeline, $newRhsPipeline, $pipelineChainAst.Operator, $pipelineChainAst.Background)
     }
 }
 #endregion


### PR DESCRIPTION
Previously introduced support for pipeline chain operators were poorly tested and erroneously attempted to recurse on the op token